### PR TITLE
fix: add netsuite/soap.rb shim so Bundler.require loads the gem

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,8 @@ Requires Ruby 3.4.
 ## Quick start
 
 ```ruby
+require 'netsuite'
+
 NetSuite.configure do
   reset!
   account       ENV['NETSUITE_ACCOUNT']

--- a/lib/netsuite/soap.rb
+++ b/lib/netsuite/soap.rb
@@ -1,0 +1,1 @@
+require 'netsuite'


### PR DESCRIPTION
## Summary

- Adds `lib/netsuite/soap.rb` shim so `Bundler.require` correctly loads the gem after the rename from `netsuite` → `netsuite-soap`
- Adds `require 'netsuite'` to the README quick start to make the gem name / require path split explicit

## Root cause

Bundler converts hyphens to slashes when auto-requiring gems, so `netsuite-soap` causes it to try `require 'netsuite/soap'`. That file didn't exist — the require failed silently and `lib/netsuite.rb` was never loaded, causing `NameError: uninitialized constant NetSuite::Actions` in specs.

Creating `lib/netsuite/soap.rb` with `require 'netsuite'` is the standard gem convention fix for when a gem's name doesn't match its require path.

## Test plan

- [ ] `bundle exec rspec spec/netsuite/actions/add_spec.rb` no longer errors on load
- [ ] `bundle exec rspec` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)