### PR TITLE
fix: add netsuite/soap.rb shim so
    Bundler.require loads the gem

### DIFF
--- a/lib/netsuite/soap.rb
+++ b/lib/netsuite/soap.rb
@@ -1,0 +1,1 @@
+require 'netsuite'


### PR DESCRIPTION
Cherry-pick from the previous fix/gem-require-path branch so
    Bundler.require loads netsuite/soap.rb in gems that pull it in.